### PR TITLE
Implement .sfz export

### DIFF
--- a/multirec/Cargo.toml
+++ b/multirec/Cargo.toml
@@ -26,4 +26,4 @@ thiserror = "1.0.48"
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 autosam = { path = "../autosam", version = "0.1.0", features = ["std"] }
-dot-multisample = { path = "../dot-multisample" }
+dot-multisample = { path = "../dot-multisample", version = "0.1.0" }

--- a/multirec/src/arguments.rs
+++ b/multirec/src/arguments.rs
@@ -105,5 +105,6 @@ pub struct Timing {
 pub enum OutputFormat {
     Raw,
     Zip,
+    Sfz,
     Bitwig,
 }


### PR DESCRIPTION
Also fixes a couple of small bugs:
- Bitwig format did not set max velocity for lowest-velocity layer
- First round robin group would skip index 2